### PR TITLE
Update [...2]security.md

### DIFF
--- a/src/routes/docs/[...2]security.md
+++ b/src/routes/docs/[...2]security.md
@@ -34,7 +34,9 @@ app.UseAuthorization();
 app.UseFastEndpoints();
 app.Run();
 ```
-
+:::admonition type="warning" Be aware that in case you are injecting builder.Services.AddIdentity<TUser,TRole>(...) which is used for IdentityDbContext then you would need to change the order in which you are injecting this service because it automatically sets CookieAuthentication as the default and messes with Endpoints functionality when you only want JWT Authentication. 
+So in order to go around this you would need to inject first the AddIdentity method and then follow with the builder.Services.AddJWTBearerAuth("TokenSigningKey") along with .AddAuthentication(o => o.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme) 
+:::
 ## Generating JWT Tokens
 
 You can generate a JWT token for sending to the client with an endpoint that signs in users like so:


### PR DESCRIPTION
Issue with .AddIdentity Service setting CookieAuthentication as defaults when only JWT Authentication is being used in FastEndpoints.